### PR TITLE
logの名前を指定可能にする

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -9,7 +9,7 @@ from webcface.field import Field
 from webcface.func import Func
 from webcface.func_info import Arg, ValType, FuncNotFoundError
 from webcface.view import ViewComponent
-from webcface.log_handler import LogLine
+from webcface.log_handler import LogLine, LogData
 import webcface.func_info
 import webcface.view_components
 
@@ -137,9 +137,9 @@ def test_entry(wcli):
     assert len(m.func("b").args) == 1
     assert m.func("b").exists() is True
 
-    assert m.log().exists() is False
-    send_back(wcli, [LogEntry.new(10)])
-    assert m.log().exists() is True
+    assert m.log("b").exists() is False
+    send_back(wcli, [LogEntry.new(10, "b")])
+    assert m.log("b").exists() is True
 
     m.on_sync(callback)
     send_back(wcli, [Sync.new_full(10, 0)])
@@ -319,29 +319,35 @@ def test_view_req(wcli):
 
 
 def test_log_send(wcli):
-    ls = [
+    ls = LogData()
+    ls.data = [
         LogLine(0, datetime.datetime.now(), "a" * 100000),
         LogLine(1, datetime.datetime.now(), "b"),
     ]
-    wcli._data_check().log_store.set_recv(self_name, ls)
+    wcli._data_check().log_store.set_send("hoge", ls)
     wcli.sync()
     m = check_sent(wcli, Log)
     assert isinstance(m, Log)
+    assert m.field == "hoge"
     assert len(m.log) == 2
     assert m.log[0].level == 0
     assert m.log[0].message == "a" * 100000
     assert m.log[1].level == 1
     assert m.log[1].message == "b"
+    assert ls.sent_lines == 2
     clear_sent(wcli)
     wcli._data_check()._msg_first = True
 
-    ls.append(LogLine(2, datetime.datetime.now(), "c"))
+    ls.data.append(LogLine(2, datetime.datetime.now(), "c"))
+    wcli._data_check().log_store.set_send("hoge", ls)
     wcli.sync()
     m = check_sent(wcli, Log)
     assert isinstance(m, Log)
+    assert m.field == "hoge"
     assert len(m.log) == 1
     assert m.log[0].level == 2
     assert m.log[0].message == "c"
+    assert ls.sent_lines == 3
 
 
 def test_log_req(wcli):
@@ -352,17 +358,19 @@ def test_log_req(wcli):
         called += 1
 
     wcli._data_check()._msg_first = True
-    wcli.member("a").log().on_change(callback)
+    wcli.member("a").log("b").on_change(callback)
     m = check_sent(wcli, LogReq)
     assert isinstance(m, LogReq)
-    assert m.member_name == "a"
+    assert m.member == "a"
+    assert m.field == "b"
+    assert m.req_id == 1
 
     send_back(
         wcli,
         [
             SyncInit.new_full("a", 10, "", "", ""),
-            Log.new_full(
-                10,
+            Log.new(
+                "b",
                 [
                     LogLine(0, datetime.datetime.now(), "a" * 100000),
                     LogLine(1, datetime.datetime.now(), "b"),
@@ -378,8 +386,8 @@ def test_log_req(wcli):
     send_back(
         wcli,
         [
-            Log.new_full(
-                10,
+            Log.new(
+                "b",
                 [
                     LogLine(2, datetime.datetime.now(), "c"),
                 ],
@@ -393,8 +401,8 @@ def test_log_req(wcli):
     send_back(
         wcli,
         [
-            Log.new_full(
-                10,
+            Log.new(
+                "b",
                 [
                     LogLine(3, datetime.datetime.now(), "d"),
                 ],

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -369,8 +369,9 @@ def test_log_req(wcli):
         wcli,
         [
             SyncInit.new_full("a", 10, "", "", ""),
-            Log.new(
-                "b",
+            LogRes.new(
+                1,
+                "",
                 [
                     LogLine(0, datetime.datetime.now(), "a" * 100000),
                     LogLine(1, datetime.datetime.now(), "b"),
@@ -379,15 +380,16 @@ def test_log_req(wcli):
         ],
     )
     assert called == 1
-    assert len(wcli._data_check().log_store.get_recv("a")) == 2
-    assert wcli._data_check().log_store.get_recv("a")[0].level == 0
-    assert wcli._data_check().log_store.get_recv("a")[0].message == "a" * 100000
+    assert len(wcli._data_check().log_store.get_recv("a", "b").data) == 2
+    assert wcli._data_check().log_store.get_recv("a", "b").data[0].level == 0
+    assert wcli._data_check().log_store.get_recv("a", "b").data[0].message == "a" * 100000
 
     send_back(
         wcli,
         [
-            Log.new(
-                "b",
+            LogRes.new(
+                1,
+                "",
                 [
                     LogLine(2, datetime.datetime.now(), "c"),
                 ],
@@ -395,14 +397,15 @@ def test_log_req(wcli):
         ],
     )
     assert called == 2
-    assert len(wcli._data_check().log_store.get_recv("a")) == 3
+    assert len(wcli._data_check().log_store.get_recv("a", "b").data) == 3
 
     webcface.Log.keep_lines = 2
     send_back(
         wcli,
         [
-            Log.new(
-                "b",
+            LogRes.new(
+                1,
+                "",
                 [
                     LogLine(3, datetime.datetime.now(), "d"),
                 ],
@@ -410,9 +413,9 @@ def test_log_req(wcli):
         ],
     )
     assert called == 3
-    assert len(wcli._data_check().log_store.get_recv("a")) == 2
-    assert wcli._data_check().log_store.get_recv("a")[0].level == 2
-    assert wcli._data_check().log_store.get_recv("a")[1].level == 3
+    assert len(wcli._data_check().log_store.get_recv("a", "b").data) == 2
+    assert wcli._data_check().log_store.get_recv("a", "b").data[0].level == 2
+    assert wcli._data_check().log_store.get_recv("a", "b").data[1].level == 3
 
 
 def test_func_info(wcli):

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -6,7 +6,7 @@ from webcface.text import Text
 from webcface.log import Log
 from webcface.field import Field
 from webcface.member import Member
-from webcface.log_handler import LogLine
+from webcface.log_handler import LogLine, LogData
 
 
 def test_value_member(data):
@@ -176,37 +176,43 @@ def test_text_set(data):
 
 
 def test_log_member(data):
-    assert isinstance(Log(Field(data, "a")).member, Member)
-    assert Log(Field(data, "a")).member.name == "a"
+    assert isinstance(Log(Field(data, "a"), "b").member, Member)
+    assert Log(Field(data, "a"), "b").member.name == "a"
 
 
 def text_log_try_get(data):
-    assert Log(Field(data, "a")).try_get() is None
-    assert data.log_store.req.get("a", False) is True
+    assert Log(Field(data, "a"), "b").try_get() is None
+    assert data.log_store.req.get("a", {}).get("b")
 
-    Log(Field(data, self_name)).try_get()
+    Log(Field(data, self_name), "b").try_get()
     assert self_name not in data.log_store.req
 
-    data.log_store.data_recv["a"] = [LogLine(1, datetime.datetime.now(), "a")]
-    assert len(Log(Field(data, "a")).try_get()) == 1
-    assert Log(Field(data, "a")).try_get()[0].level == 1
-    assert Log(Field(data, "a")).try_get()[0].message == "a"
+    log_data = LogData()
+    log_data.data = [LogLine(1, datetime.datetime.now(), "a")]
+    data.log_store.data_recv["a"] = {"b": log_data}
+    assert len(Log(Field(data, "a"), "b").try_get()) == 1
+    assert Log(Field(data, "a"), "b").try_get()[0].level == 1
+    assert Log(Field(data, "a"), "b").try_get()[0].message == "a"
 
 
 def test_log_get(data):
-    assert Log(Field(data, "a")).get() == []
-    assert data.log_store.req.get("a", False) is True
+    assert Log(Field(data, "a"), "b").get() == []
+    assert data.log_store.req.get("a", {}).get("b") == 1
 
-    Log(Field(data, self_name)).get()
+    Log(Field(data, self_name), "b").get()
     assert self_name not in data.log_store.req
 
-    data.log_store.data_recv["a"] = [LogLine(1, datetime.datetime.now(), "a")]
-    assert len(Log(Field(data, "a")).get()) == 1
-    assert Log(Field(data, "a")).get()[0].level == 1
-    assert Log(Field(data, "a")).get()[0].message == "a"
+    log_data = LogData()
+    log_data.data = [LogLine(1, datetime.datetime.now(), "a")]
+    data.log_store.data_recv["a"] = {"b": log_data}
+    assert len(Log(Field(data, "a"), "b").get()) == 1
+    assert Log(Field(data, "a"), "b").get()[0].level == 1
+    assert Log(Field(data, "a"), "b").get()[0].message == "a"
 
 
 def test_log_clear(data):
-    data.log_store.data_recv["a"] = [LogLine(1, datetime.datetime.now(), "a")]
-    Log(Field(data, "a")).clear()
-    assert data.log_store.data_recv["a"] == []
+    log_data = LogData()
+    log_data.data = [LogLine(1, datetime.datetime.now(), "a")]
+    data.log_store.data_recv["a"] = {"b": log_data}
+    Log(Field(data, "a"), "b").clear()
+    assert len(data.log_store.data_recv["a"]["b"].data) == 0

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -1,28 +1,28 @@
 from conftest import self_name
 from logging import getLogger, DEBUG
-
+from webcface.log_handler import Handler, LogWriteIO
 
 def test_logger_handler(data):
     logger = getLogger("main")
     logger.setLevel(DEBUG)
     # logger.addHandler(StreamHandler())
-    logger.addHandler(data.logging_handler)
+    logger.addHandler(Handler(data, "b"))
     logger.debug("1")
     logger.info("2")
     logger.warning("3")
     logger.error("4")
     logger.critical("5")
 
-    assert len(data.log_store.data_recv[self_name]) == 5
+    assert len(data.log_store.data_recv[self_name]["b"].data) == 5
     for i in range(5):
-        assert data.log_store.data_recv[self_name][i].level == i + 1
-        assert data.log_store.data_recv[self_name][i].message == str(i + 1)
+        assert data.log_store.data_recv[self_name]["b"].data[i].level == i + 1
+        assert data.log_store.data_recv[self_name]["b"].data[i].message == str(i + 1)
 
 
 def test_logger_io(data):
-    print("a\nb", file=data.logging_io)
-    assert len(data.log_store.data_recv[self_name]) == 2
-    assert data.log_store.data_recv[self_name][0].level == 2
-    assert data.log_store.data_recv[self_name][0].message == "a"
-    assert data.log_store.data_recv[self_name][1].level == 2
-    assert data.log_store.data_recv[self_name][1].message == "b"
+    print("a\nb", file=LogWriteIO(data, "b"))
+    assert len(data.log_store.data_recv[self_name]["b"].data) == 2
+    assert data.log_store.data_recv[self_name]["b"].data[0].level == 2
+    assert data.log_store.data_recv[self_name]["b"].data[0].message == "a"
+    assert data.log_store.data_recv[self_name]["b"].data[1].level == 2
+    assert data.log_store.data_recv[self_name]["b"].data[1].message == "b"

--- a/webcface/client.py
+++ b/webcface/client.py
@@ -262,14 +262,19 @@ class Client(webcface.member.Member):
     def logging_handler(self) -> logging.Handler:
         """webcfaceに出力するloggingのHandler
 
+        (ver2.1〜: Log名は "default", log().handler と同じ)
+
         :return: logger.addHandler にセットして使う
         """
-        return self._data_check().logging_handler
+        return webcface.log_handler.Handler(self._data_check(), "default")
 
     @property
     def logging_io(self) -> io.TextIOBase:
-        """webcfaceとstderrに出力するio"""
-        return self._data_check().logging_io
+        """webcfaceとstderrに出力するio
+
+        (ver2.1〜: Log名は "default", log().io と同じ)
+        """
+        return webcface.log_handler.LogWriteIO(self._data_check(), "default")
 
     @property
     def server_name(self) -> str:

--- a/webcface/client_data.py
+++ b/webcface/client_data.py
@@ -260,8 +260,6 @@ class ClientData:
     log_store: SyncDataStore2[webcface.log_handler.LogData]
     sync_time_store: SyncDataStore1[datetime.datetime]
     func_result_store: FuncResultStore
-    logging_handler: webcface.log_handler.Handler
-    logging_io: webcface.log_handler.LogWriteIO
     member_ids: Dict[str, int]
     member_lib_name: Dict[int, str]
     member_lib_ver: Dict[int, str]
@@ -322,8 +320,6 @@ class ClientData:
         self.log_store = SyncDataStore2[webcface.log_handler.LogData](name)
         self.sync_time_store = SyncDataStore1[datetime.datetime](name)
         self.func_result_store = FuncResultStore()
-        self.logging_handler = webcface.log_handler.Handler(self)
-        self.logging_io = webcface.log_handler.LogWriteIO(self)
         self.member_ids = {}
         self.member_lib_name = {}
         self.member_lib_ver = {}

--- a/webcface/client_data.py
+++ b/webcface/client_data.py
@@ -257,11 +257,10 @@ class ClientData:
     view_store: SyncDataStore2[List[webcface.view_base.ViewComponentBase]]
     canvas2d_store: SyncDataStore2[webcface.canvas2d_base.Canvas2DData]
     canvas3d_store: SyncDataStore2[List[webcface.canvas3d_base.Canvas3DComponentBase]]
-    log_store: SyncDataStore1[List[webcface.log_handler.LogLine]]
+    log_store: SyncDataStore2[webcface.log_handler.LogData]
     sync_time_store: SyncDataStore1[datetime.datetime]
     func_result_store: FuncResultStore
     logging_handler: webcface.log_handler.Handler
-    log_sent_lines: int
     logging_io: webcface.log_handler.LogWriteIO
     member_ids: Dict[str, int]
     member_lib_name: Dict[int, str]
@@ -291,6 +290,7 @@ class ClientData:
     on_func_entry: Dict[str, Callable]
     on_canvas2d_entry: Dict[str, Callable]
     on_canvas3d_entry: Dict[str, Callable]
+    on_log_entry: Dict[str, Callable]
     on_sync: Dict[str, Callable]
     on_value_change: Dict[str, Dict[str, Callable]]
     on_text_change: Dict[str, Dict[str, Callable]]
@@ -319,9 +319,7 @@ class ClientData:
         self.canvas3d_store = SyncDataStore2[
             List[webcface.canvas3d_base.Canvas3DComponentBase]
         ](name)
-        self.log_store = SyncDataStore1[List[webcface.log_handler.LogLine]](name)
-        self.log_store.set_recv(name, [])
-        self.log_sent_lines = 0
+        self.log_store = SyncDataStore2[webcface.log_handler.LogData](name)
         self.sync_time_store = SyncDataStore1[datetime.datetime](name)
         self.func_result_store = FuncResultStore()
         self.logging_handler = webcface.log_handler.Handler(self)
@@ -354,6 +352,7 @@ class ClientData:
         self.on_func_entry = {}
         self.on_canvas2d_entry = {}
         self.on_canvas3d_entry = {}
+        self.on_log_entry = {}
         self.on_sync = {}
         self.on_value_change = {}
         self.on_text_change = {}

--- a/webcface/log.py
+++ b/webcface/log.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 from typing import Optional, List, Callable
+import logging
+import io
 import datetime
 import webcface.field
 import webcface.member
@@ -101,3 +103,19 @@ class Log(webcface.field.Field):
                 log_data = webcface.log_handler.LogData()
             log_data.data.append(webcface.log_handler.LogLine(level, time, message))
             data.log_store.set_send(self._field, log_data)
+
+    @property
+    def handler(self) -> logging.Handler:
+        """webcfaceに出力するloggingのHandler
+        (ver2.1〜)
+
+        :return: logger.addHandler にセットして使う
+        """
+        return webcface.log_handler.Handler(self._data_check(), self._field)
+
+    @property
+    def io(self) -> io.TextIOBase:
+        """webcfaceとstderrに出力するio
+        (ver2.1〜)
+        """
+        return webcface.log_handler.LogWriteIO(self._data_check(), self._field)

--- a/webcface/log.py
+++ b/webcface/log.py
@@ -9,7 +9,7 @@ import webcface.log_handler
 class Log(webcface.field.Field):
     keep_lines: int = 1000
 
-    def __init__(self, base: webcface.field.Field) -> None:
+    def __init__(self, base: webcface.field.Field, field: str = "") -> None:
         """Logを指すクラス
 
         このコンストラクタを直接使わず、
@@ -17,12 +17,19 @@ class Log(webcface.field.Field):
 
         詳細は `Logのドキュメント <https://na-trium-144.github.io/webcface/md_40__log.html>`_ を参照
         """
-        super().__init__(base._data, base._member)
+        super().__init__(
+            base._data, base._member, field if field != "" else base._field
+        )
 
     @property
     def member(self) -> webcface.member.Member:
         """Memberを返す"""
         return webcface.member.Member(self)
+
+    @property
+    def name(self) -> str:
+        """field名を返す(ver2.1〜)"""
+        return self._field
 
     def on_change(self, func: Callable) -> Callable:
         """logが追加されたときのイベント
@@ -38,16 +45,20 @@ class Log(webcface.field.Field):
 
     def request(self) -> None:
         """値の受信をリクエストする"""
-        req = self._data_check().log_store.add_req(self._member)
+        req = self._data_check().log_store.add_req(self._member, self._field)
         if req:
             self._data_check().queue_msg_req(
-                [webcface.message.LogReq.new(self._member)]
+                [webcface.message.LogReq.new(self._member, self._field, req)]
             )
 
     def try_get(self) -> Optional[List[webcface.log_handler.LogLine]]:
         """ログをlistまたはNoneで返す、まだリクエストされてなければ自動でリクエストされる"""
         self.request()
-        return self._data_check().log_store.get_recv(self._member)
+        log_data = self._data_check().log_store.get_recv(self._member, self._field)
+        if log_data is not None:
+            return log_data.data[:]
+        else:
+            return None
 
     def get(self) -> List[webcface.log_handler.LogLine]:
         """ログをlistで返す、まだリクエストされてなければ自動でリクエストされる"""
@@ -58,7 +69,9 @@ class Log(webcface.field.Field):
         """受信したログを空にする
 
         リクエスト状態はクリアしない"""
-        self._data_check().log_store.set_recv(self._member, [])
+        log_data = self._data_check().log_store.get_recv(self._member, self._field)
+        if log_data is not None:
+            log_data.data = []
         return self
 
     def exists(self) -> bool:
@@ -68,7 +81,7 @@ class Log(webcface.field.Field):
         try_get() などとは違って、実際のデータを受信しない。
         リクエストもしない。
         """
-        return self._data_check().log_store.get_entry(self._member) is True
+        return self._field in self._data_check().log_store.get_entry(self._member)
 
     def append(
         self,
@@ -83,6 +96,8 @@ class Log(webcface.field.Field):
         """
         data = self._set_check()
         with data.log_store.lock:
-            ls = data.log_store.get_recv(self._member)
-            assert ls is not None
-            ls.append(webcface.log_handler.LogLine(level, time, message))
+            log_data = data.log_store.get_recv(self._member, self._field)
+            if log_data is None:
+                log_data = webcface.log_handler.LogData()
+            log_data.data.append(webcface.log_handler.LogLine(level, time, message))
+            data.log_store.set_send(self._field, log_data)

--- a/webcface/log_handler.py
+++ b/webcface/log_handler.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 import io
-from typing import Iterable
+from typing import Iterable, List
 import sys
 import logging
 import datetime
 import webcface.client_data
+
+
+class LogData:
+    data: List[LogLine]
+    sent_lines: int
+
+    def __init__(self) -> None:
+        self.data = []
+        self.sent_lines = 0
 
 
 class LogLine:

--- a/webcface/log_handler.py
+++ b/webcface/log_handler.py
@@ -28,34 +28,30 @@ class LogLine:
 
 
 class Handler(logging.Handler):
-    _data: webcface.client_data.ClientData
+    _log: webcface.log.Log
 
-    def __init__(self, data: webcface.client_data.ClientData) -> None:
+    def __init__(self, data: webcface.client_data.ClientData, name: str) -> None:
         super().__init__(logging.NOTSET)
-        self._data = data
-
-    def emit(self, record: logging.LogRecord) -> None:
-        self.write(
-            LogLine(
-                record.levelno // 10,
-                datetime.datetime.fromtimestamp(record.created),
-                record.getMessage(),
-            )
+        self._log = webcface.log.Log(
+            webcface.field.Field(data, data.self_member_name), name
         )
 
-    def write(self, line: LogLine) -> None:
-        with self._data.log_store.lock:
-            ls = self._data.log_store.get_recv(self._data.self_member_name)
-            assert ls is not None
-            ls.append(line)
+    def emit(self, record: logging.LogRecord) -> None:
+        self._log.append(
+            record.levelno // 10,
+            record.getMessage(),
+            datetime.datetime.fromtimestamp(record.created),
+        )
 
 
 class LogWriteIO(io.TextIOBase):
-    _data: webcface.client_data.ClientData
+    _log: webcface.log.Log
 
-    def __init__(self, data: webcface.client_data.ClientData) -> None:
+    def __init__(self, data: webcface.client_data.ClientData, name: str) -> None:
         super().__init__()
-        self._data = data
+        self._log = webcface.log.Log(
+            webcface.field.Field(data, data.self_member_name), name
+        )
 
     def isatty(self) -> bool:
         """:return: False"""
@@ -77,5 +73,5 @@ class LogWriteIO(io.TextIOBase):
         """webcfaceに文字列を出力すると同時にsys.__stderr__にも流す"""
         for l in s.split("\n"):
             if len(l) > 0:
-                self._data.logging_handler.write(LogLine(2, datetime.datetime.now(), l))
-        return sys.__stdout__.write(s)
+                self._log.append(2, l, datetime.datetime.now())
+        return sys.__stderr__.write(s)

--- a/webcface/member.py
+++ b/webcface/member.py
@@ -60,13 +60,14 @@ class Member(webcface.field.Field):
         """Canvas3Dオブジェクトを生成"""
         return webcface.canvas3d.Canvas3D(self, field)
 
-    def log(self) -> webcface.log.Log:
-        """Logオブジェクトを生成"""
-        return webcface.log.Log(self)
+    def log(self, field: str = "default") -> webcface.log.Log:
+        """Logオブジェクトを生成
 
-    def func(
-        self, arg: str = "", **kwargs
-    ) -> webcface.func.Func:
+        :arg field: (ver2.1〜) Logの名前を指定可能(省略すると"default")
+        """
+        return webcface.log.Log(self, field)
+
+    def func(self, arg: str = "", **kwargs) -> webcface.func.Func:
         """Funcオブジェクトを生成
 
         #. member.func(arg: str)
@@ -139,6 +140,10 @@ class Member(webcface.field.Field):
             self.canvas3d, self._data_check().canvas3d_store.get_entry(self._member)
         )
 
+    def log_entries(self) -> Iterable[webcface.log.Log]:
+        """このメンバーのLogをすべて取得する。(ver2.1〜)"""
+        return map(self.log, self._data_check().log_store.get_entry(self._member))
+
     def on_value_entry(self, func: Callable) -> Callable:
         """Valueが追加されたときのイベント
 
@@ -185,6 +190,14 @@ class Member(webcface.field.Field):
         コールバックの引数にはCanvas3Dオブジェクトが渡される。
         """
         self._data_check().on_canvas3d_entry[self._member] = func
+        return func
+
+    def on_log_entry(self, func: Callable) -> Callable:
+        """Logが追加されたときのイベント(ver2.1〜)
+
+        コールバックの引数にはLogオブジェクトが渡される。
+        """
+        self._data_check().on_log_entry[self._member] = func
         return func
 
     def on_sync(self, func: Callable) -> Callable:


### PR DESCRIPTION
* Logの名前指定可能,新Logメッセージに移行
* Member.log\_entries, on\_log\_entry 追加
* Log.name, Log.handler, Log.io
* log_handlerがstderrに出力と書いてあったのに実際にはstdoutに出力していたバグ?を修正
