### PR TITLE
Field機能追加

### DIFF
--- a/webcface/canvas2d.py
+++ b/webcface/canvas2d.py
@@ -155,11 +155,8 @@ class Canvas2D(webcface.field.Field):
         return func
 
     def child(self, field: str) -> "Canvas2D":
-        """子フィールドを返す
-
-        :return: 「(thisのフィールド名).(子フィールド名)」をフィールド名とするView
-        """
-        return Canvas2D(self, self._field + "." + field)
+        """「(thisの名前).(追加の名前)」を新しい名前とするCanvas2D"""
+        return Canvas2D(webcface.field.Field.child(self, field))
 
     def request(self) -> None:
         """値の受信をリクエストする"""

--- a/webcface/canvas2d.py
+++ b/webcface/canvas2d.py
@@ -101,7 +101,8 @@ class Canvas2DComponent(webcface.canvas2d_base.Canvas2DComponentBase):
         )
 
 
-class Canvas2D(webcface.field.Field):
+class Canvas2D:
+    _base: "webcface.field.Field"
     _c2data: "Optional[Canvas2DData]"
     _modified: bool
 
@@ -121,7 +122,7 @@ class Canvas2D(webcface.field.Field):
 
         詳細は `Canvas2Dのドキュメント <https://na-trium-144.github.io/webcface/md_14__canvas2d.html>`_ を参照
         """
-        super().__init__(
+        self._base = webcface.field.Field(
             base._data, base._member, field if field != "" else base._field
         )
         self._c2data = None
@@ -132,12 +133,12 @@ class Canvas2D(webcface.field.Field):
     @property
     def member(self) -> "webcface.member.Member":
         """Memberを返す"""
-        return webcface.member.Member(self)
+        return webcface.member.Member(self._base)
 
     @property
     def name(self) -> str:
         """field名を返す"""
-        return self._field
+        return self._base._field
 
     def on_change(self, func: Callable) -> Callable:
         """値が変化したときのイベント
@@ -148,32 +149,40 @@ class Canvas2D(webcface.field.Field):
         まだ値をリクエストされてなければ自動でリクエストされる
         """
         self.request()
-        data = self._data_check()
-        if self._member not in data.on_canvas2d_change:
-            data.on_canvas2d_change[self._member] = {}
-        data.on_canvas2d_change[self._member][self._field] = func
+        data = self._base._data_check()
+        if self._base._member not in data.on_canvas2d_change:
+            data.on_canvas2d_change[self._base._member] = {}
+        data.on_canvas2d_change[self._base._member][self._base._field] = func
         return func
 
     def child(self, field: str) -> "Canvas2D":
         """「(thisの名前).(追加の名前)」を新しい名前とするCanvas2D"""
-        return Canvas2D(webcface.field.Field.child(self, field))
+        return Canvas2D(self._base.child(field))
 
     def request(self) -> None:
         """値の受信をリクエストする"""
-        req = self._data_check().canvas2d_store.add_req(self._member, self._field)
+        req = self._base._data_check().canvas2d_store.add_req(
+            self._base._member, self._base._field
+        )
         if req > 0:
-            self._data_check().queue_msg_req(
-                [webcface.message.Canvas2DReq.new(self._member, self._field, req)]
+            self._base._data_check().queue_msg_req(
+                [
+                    webcface.message.Canvas2DReq.new(
+                        self._base._member, self._base._field, req
+                    )
+                ]
             )
 
     def try_get(self) -> "Optional[List[Canvas2DComponent]]":
         """CanvasをlistまたはNoneで返す、まだリクエストされてなければ自動でリクエストされる"""
         self.request()
-        v = self._data_check().canvas2d_store.get_recv(self._member, self._field)
+        v = self._base._data_check().canvas2d_store.get_recv(
+            self._base._member, self._base._field
+        )
         v2: Optional[List[Canvas2DComponent]] = None
         if v is not None:
             v2 = [
-                Canvas2DComponent(v.components[v_id], self._data, v_id)
+                Canvas2DComponent(v.components[v_id], self._base._data, v_id)
                 for v_id in v.ids
             ]
         return v2
@@ -190,7 +199,9 @@ class Canvas2D(webcface.field.Field):
         try_get() などとは違って、実際のデータを受信しない。
         リクエストもしない。
         """
-        return self._field in self._data_check().canvas2d_store.get_entry(self._member)
+        return self._base._field in self._base._data_check().canvas2d_store.get_entry(
+            self._base._member
+        )
 
     @property
     def width(self) -> float:
@@ -201,7 +212,9 @@ class Canvas2D(webcface.field.Field):
             return self._c2data.width
         else:
             self.request()
-            v = self._data_check().canvas2d_store.get_recv(self._member, self._field)
+            v = self._base._data_check().canvas2d_store.get_recv(
+                self._base._member, self._base._field
+            )
             if v is not None:
                 return v.width
             else:
@@ -216,7 +229,9 @@ class Canvas2D(webcface.field.Field):
             return self._c2data.height
         else:
             self.request()
-            v = self._data_check().canvas2d_store.get_recv(self._member, self._field)
+            v = self._base._data_check().canvas2d_store.get_recv(
+                self._base._member, self._base._field
+            )
             if v is not None:
                 return v.height
             else:
@@ -240,20 +255,19 @@ class Canvas2D(webcface.field.Field):
 
     def sync(self) -> "Canvas2D":
         """Viewの内容をclientに反映し送信可能にする"""
-        self._set_check()
+        data = self._base._set_check()
         if self._modified and self._c2data is not None:
-            data = self._set_check()
             data_idx: Dict[int, int] = {}
             for c in self._c2data.tmp_components:
                 idx = data_idx.get(c._canvas2d_type, 0)
                 data_idx[c._canvas2d_type] = idx + 1
-                c.lock_tmp(data, "c2", self._field, f"..{c._canvas2d_type}.{idx}")
+                c.lock_tmp(data, "c2", self._base._field, f"..{c._canvas2d_type}.{idx}")
                 self._c2data.components[c.id] = c.to_canvas2d()
                 self._c2data.ids.append(c.id)
-            self._set_check().canvas2d_store.set_send(self._field, self._c2data)
+            data.canvas2d_store.set_send(self._base._field, self._c2data)
             self._modified = False
-        on_change = (
-            self._data_check().on_canvas2d_change.get(self._member, {}).get(self._field)
+        on_change = data.on_canvas2d_change.get(self._base._member, {}).get(
+            self._base._field
         )
         if on_change is not None:
             on_change(self)

--- a/webcface/canvas3d.py
+++ b/webcface/canvas3d.py
@@ -141,11 +141,8 @@ class Canvas3D(webcface.field.Field):
         return func
 
     def child(self, field: str) -> "Canvas3D":
-        """子フィールドを返す
-
-        :return: 「(thisのフィールド名).(子フィールド名)」をフィールド名とするView
-        """
-        return Canvas3D(self, self._field + "." + field)
+        """「(thisの名前).(追加の名前)」を新しい名前とするCanvas3D"""
+        return Canvas3D(webcface.field.Field.child(self, field))
 
     def request(self) -> None:
         """値の受信をリクエストする"""

--- a/webcface/components.py
+++ b/webcface/components.py
@@ -22,7 +22,9 @@ def new_line(**kwargs) -> "webcface.temporal_component.TemporalComponent":
 
 def button(
     text: str,
-    on_click: "Union[webcface.field.FieldBase, Callable]",
+    on_click: Union[
+        "webcface.func.Func", "webcface.func_listener.FuncListener", Callable
+    ],
     **kwargs,
 ) -> "webcface.temporal_component.TemporalComponent":
     """button要素"""

--- a/webcface/field.py
+++ b/webcface/field.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Iterable, SupportsFloat, List
+from typing import Optional, Iterable, SupportsFloat, List
 import webcface.client_data
 import webcface.value
 import webcface.text
@@ -68,11 +68,11 @@ class Field(FieldBase):
         return Field(self._data, self._member, new_field)
 
     def value(self, field: str = "") -> "webcface.value.Value":
-        """Valueオブジェクトを生成(ver3.1〜)"""
+        """Valueオブジェクトを生成(ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         return webcface.value.Value(self.child(field))
 
     def text(self, field: str = "") -> "webcface.text.Text":
-        """Textオブジェクトを生成(ver3.1〜)"""
+        """Textオブジェクトを生成(ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         return webcface.text.Text(self.child(field))
 
     def variant(self, field: str = "") -> "webcface.text.Variant":
@@ -80,11 +80,11 @@ class Field(FieldBase):
         return webcface.text.Variant(self.child(field))
 
     def image(self, field: str = "") -> "webcface.image.Image":
-        """Imageオブジェクトを生成(ver3.1〜)"""
+        """Imageオブジェクトを生成(ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         return webcface.image.Image(self.child(field))
 
     def view(self, field: str = "") -> "webcface.view.View":
-        """Viewオブジェクトを生成(ver3.1〜)"""
+        """Viewオブジェクトを生成(ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         return webcface.view.View(self.child(field))
 
     def canvas2d(
@@ -93,25 +93,25 @@ class Field(FieldBase):
         width: Optional[SupportsFloat] = None,
         height: Optional[SupportsFloat] = None,
     ) -> "webcface.canvas2d.Canvas2D":
-        """Canvas2Dオブジェクトを生成(ver3.1〜)
+        """Canvas2Dオブジェクトを生成(ver3.1〜 / ver3.0までMemberクラスのメソッド)
 
         :arg width, height: Canvas2Dのサイズを指定して初期化する
         """
         return webcface.canvas2d.Canvas2D(self, field, width, height)
 
     def canvas3d(self, field: str = "") -> "webcface.canvas3d.Canvas3D":
-        """Canvas3Dオブジェクトを生成(ver3.1〜)"""
+        """Canvas3Dオブジェクトを生成(ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         return webcface.canvas3d.Canvas3D(self.child(field))
 
     def log(self, field: str = "default") -> "webcface.log.Log":
-        """Logオブジェクトを生成(ver3.1〜)
+        """Logオブジェクトを生成(ver3.1〜 / ver3.0までMemberクラスのメソッド)
 
         :arg field: (ver2.1〜) Logの名前を指定可能(省略すると"default")
         """
         return webcface.log.Log(self.child(field))
 
     def func(self, arg: str = "", **kwargs) -> "webcface.func.Func":
-        """Funcオブジェクトを生成(ver3.1〜)
+        """Funcオブジェクトを生成(ver3.1〜 / ver3.0までMemberクラスのメソッド)
 
         #. member.func(arg: str)
             * 指定した名前のFuncオブジェクトを生成・参照する。
@@ -126,7 +126,7 @@ class Field(FieldBase):
         return webcface.func.Func(self.child(arg), **kwargs)
 
     def func_listener(self, field: str = "") -> "webcface.func_listener.FuncListener":
-        """FuncListenerオブジェクトを生成(ver3.1〜)"""
+        """FuncListenerオブジェクトを生成(ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         return webcface.func_listener.FuncListener(self.child(field))
 
     def _entries(self, entries: List[str], store, recurse=True):
@@ -177,49 +177,49 @@ class Field(FieldBase):
         )
 
     def value_entries(self) -> "Iterable[webcface.value.Value]":
-        """「(thisの名前).(追加の名前)」で公開されているvalueをすべて取得する (ver3.1〜)"""
+        """「(thisの名前).(追加の名前)」で公開されているvalueをすべて取得する (ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         entries: List[str] = []
         self._entries(entries, self._data_check().value_store, True)
         return map(lambda n: webcface.value.Value(self, n), entries)
 
     def text_entries(self) -> "Iterable[webcface.text.Text]":
-        """「(thisの名前).(追加の名前)」で公開されているtextをすべて取得する (ver3.1〜)"""
+        """「(thisの名前).(追加の名前)」で公開されているtextをすべて取得する (ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         entries: List[str] = []
         self._entries(entries, self._data_check().text_store, True)
         return map(lambda n: webcface.text.Text(self, n), entries)
 
     def image_entries(self) -> "Iterable[webcface.image.Image]":
-        """「(thisの名前).(追加の名前)」で公開されているimageをすべて取得する (ver3.1〜)"""
+        """「(thisの名前).(追加の名前)」で公開されているimageをすべて取得する (ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         entries: List[str] = []
         self._entries(entries, self._data_check().image_store, True)
         return map(lambda n: webcface.image.Image(self, n), entries)
 
     def view_entries(self) -> "Iterable[webcface.view.View]":
-        """「(thisの名前).(追加の名前)」で公開されているviewをすべて取得する (ver3.1〜)"""
+        """「(thisの名前).(追加の名前)」で公開されているviewをすべて取得する (ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         entries: List[str] = []
         self._entries(entries, self._data_check().view_store, True)
         return map(lambda n: webcface.view.View(self, n), entries)
 
     def func_entries(self) -> "Iterable[webcface.func.Func]":
-        """「(thisの名前).(追加の名前)」で公開されているfuncをすべて取得する (ver3.1〜)"""
+        """「(thisの名前).(追加の名前)」で公開されているfuncをすべて取得する (ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         entries: List[str] = []
         self._entries(entries, self._data_check().func_store, True)
         return map(lambda n: webcface.func.Func(self, n), entries)
 
     def canvas2d_entries(self) -> "Iterable[webcface.canvas2d.Canvas2D]":
-        """「(thisの名前).(追加の名前)」で公開されているcanvas2dをすべて取得する (ver3.1〜)"""
+        """「(thisの名前).(追加の名前)」で公開されているcanvas2dをすべて取得する (ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         entries: List[str] = []
         self._entries(entries, self._data_check().canvas2d_store, True)
         return map(lambda n: webcface.canvas2d.Canvas2D(self, n), entries)
 
     def canvas3d_entries(self) -> "Iterable[webcface.canvas3d.Canvas3D]":
-        """「(thisの名前).(追加の名前)」で公開されているcanvas3dをすべて取得する (ver3.1〜)"""
+        """「(thisの名前).(追加の名前)」で公開されているcanvas3dをすべて取得する (ver3.1〜 / ver3.0までMemberクラスのメソッド)"""
         entries: List[str] = []
         self._entries(entries, self._data_check().canvas3d_store, True)
         return map(lambda n: webcface.canvas3d.Canvas3D(self, n), entries)
 
     def log_entries(self) -> "Iterable[webcface.log.Log]":
-        """「(thisの名前).(追加の名前)」で公開されているlogをすべて取得する (ver3.1〜)"""
+        """「(thisの名前).(追加の名前)」で公開されているlogをすべて取得する (ver3.1〜 / ver2.1〜3.0までMemberクラスのメソッド)"""
         entries: List[str] = []
         self._entries(entries, self._data_check().log_store, True)
         return map(lambda n: webcface.log.Log(self, n), entries)

--- a/webcface/field.py
+++ b/webcface/field.py
@@ -1,15 +1,5 @@
 from typing import Callable, Optional, Iterable, SupportsFloat, List
 import webcface.client_data
-import webcface.value
-import webcface.text
-import webcface.view
-import webcface.func
-import webcface.func_listener
-import webcface.log
-import webcface.image
-import webcface.message
-import webcface.canvas2d
-import webcface.canvas3d
 
 
 class FieldBase:
@@ -130,18 +120,17 @@ class Field(FieldBase):
         return webcface.func_listener.FuncListener(self.child(field))
 
     def _entries(self, entries: List[str], store, recurse=True):
-        entries_prev_len = len(entries)
         prefix_with_sep = self._field + "." if self._field != "" else ""
-        for e in store.get_entries(self._member):
+        for e in store.get_entry(self._member):
             if self._field == "" or e.startswith(prefix_with_sep):
-                if not recurse:
+                if not recurse and "." in e[len(prefix_with_sep) :]:
                     e = e[: e.find(".", len(prefix_with_sep))]
-                if e not in entries[:entries_prev_len]:
+                if e not in entries:
                     entries.append(e)
 
     def _has_entries(self, store) -> bool:
         prefix_with_sep = self._field + "." if self._field != "" else ""
-        for e in store.get_entries(self._member):
+        for e in store.get_entry(self._member):
             if self._field == "" or e.startswith(prefix_with_sep):
                 return True
         return False

--- a/webcface/field.py
+++ b/webcface/field.py
@@ -1,5 +1,15 @@
-from typing import Optional
+from typing import Callable, Optional, Iterable, SupportsFloat, List
 import webcface.client_data
+import webcface.value
+import webcface.text
+import webcface.view
+import webcface.func
+import webcface.func_listener
+import webcface.log
+import webcface.image
+import webcface.message
+import webcface.canvas2d
+import webcface.canvas3d
 
 
 class FieldBase:
@@ -33,3 +43,184 @@ class Field(FieldBase):
         if data.is_self(self._member):
             return data
         raise ValueError("Cannot set data to member other than self")
+
+    @property
+    def member(self) -> "webcface.member.Member":
+        """Memberを返す (ver3.1〜)"""
+        return webcface.member.Member(self)
+
+    @property
+    def name(self) -> str:
+        """field名を返す (ver3.1〜)"""
+        return self._field
+
+    def child(self, field: str) -> "Field":
+        """「(このFieldの名前).(追加の名前)」を新しい名前とするField (ver3.1〜)
+
+        * このFieldの名前が空文字列の場合はピリオドをつけず新しい名前とする。
+        """
+        if self._field == "":
+            new_field = field
+        elif field == "":
+            new_field = self._field
+        else:
+            new_field = self._field + "." + field
+        return Field(self._data, self._member, new_field)
+
+    def value(self, field: str = "") -> "webcface.value.Value":
+        """Valueオブジェクトを生成(ver3.1〜)"""
+        return webcface.value.Value(self.child(field))
+
+    def text(self, field: str = "") -> "webcface.text.Text":
+        """Textオブジェクトを生成(ver3.1〜)"""
+        return webcface.text.Text(self.child(field))
+
+    def variant(self, field: str = "") -> "webcface.text.Variant":
+        """Variantオブジェクトを生成 (ver2.0〜)"""
+        return webcface.text.Variant(self.child(field))
+
+    def image(self, field: str = "") -> "webcface.image.Image":
+        """Imageオブジェクトを生成(ver3.1〜)"""
+        return webcface.image.Image(self.child(field))
+
+    def view(self, field: str = "") -> "webcface.view.View":
+        """Viewオブジェクトを生成(ver3.1〜)"""
+        return webcface.view.View(self.child(field))
+
+    def canvas2d(
+        self,
+        field: str = "",
+        width: Optional[SupportsFloat] = None,
+        height: Optional[SupportsFloat] = None,
+    ) -> "webcface.canvas2d.Canvas2D":
+        """Canvas2Dオブジェクトを生成(ver3.1〜)
+
+        :arg width, height: Canvas2Dのサイズを指定して初期化する
+        """
+        return webcface.canvas2d.Canvas2D(self, field, width, height)
+
+    def canvas3d(self, field: str = "") -> "webcface.canvas3d.Canvas3D":
+        """Canvas3Dオブジェクトを生成(ver3.1〜)"""
+        return webcface.canvas3d.Canvas3D(self.child(field))
+
+    def log(self, field: str = "default") -> "webcface.log.Log":
+        """Logオブジェクトを生成(ver3.1〜)
+
+        :arg field: (ver2.1〜) Logの名前を指定可能(省略すると"default")
+        """
+        return webcface.log.Log(self.child(field))
+
+    def func(self, arg: str = "", **kwargs) -> "webcface.func.Func":
+        """Funcオブジェクトを生成(ver3.1〜)
+
+        #. member.func(arg: str)
+            * 指定した名前のFuncオブジェクトを生成・参照する。
+        #. @member.func(arg: str, [**kwargs])
+            * デコレータとして使い、デコレートした関数を指定した名前でセットする。
+            * デコレート後、関数は元のまま返す。
+        #. @member.func([**kwargs])
+            * 3と同じだが、名前はデコレートした関数から自動で取得される。
+
+        2, 3 の場合のkwargsは Func.set() を参照。
+        """
+        return webcface.func.Func(self.child(arg), **kwargs)
+
+    def func_listener(self, field: str = "") -> "webcface.func_listener.FuncListener":
+        """FuncListenerオブジェクトを生成(ver3.1〜)"""
+        return webcface.func_listener.FuncListener(self.child(field))
+
+    def _entries(self, entries: List[str], store, recurse=True):
+        entries_prev_len = len(entries)
+        prefix_with_sep = self._field + "." if self._field != "" else ""
+        for e in store.get_entries(self._member):
+            if self._field == "" or e.startswith(prefix_with_sep):
+                if not recurse:
+                    e = e[: e.find(".", len(prefix_with_sep))]
+                if e not in entries[:entries_prev_len]:
+                    entries.append(e)
+
+    def _has_entries(self, store) -> bool:
+        prefix_with_sep = self._field + "." if self._field != "" else ""
+        for e in store.get_entries(self._member):
+            if self._field == "" or e.startswith(prefix_with_sep):
+                return True
+        return False
+
+    def children(self, recurse=False) -> "Iterable[webcface.field.Field]":
+        """「(thisの名前).(追加の名前)」で公開されているデータをすべて取得する (ver3.1〜)
+
+        * データ型を問わずすべてのデータを列挙する。
+        * recurseがFalseの場合、名前にさらにピリオドが含まれる場合はその前までの名前を返す。
+        * 同名で複数のデータが存在する場合も1回のみカウントする。
+        """
+        entries: List[str] = []
+        self._entries(entries, self._data_check().value_store, recurse)
+        self._entries(entries, self._data_check().text_store, recurse)
+        self._entries(entries, self._data_check().image_store, recurse)
+        self._entries(entries, self._data_check().func_store, recurse)
+        self._entries(entries, self._data_check().view_store, recurse)
+        self._entries(entries, self._data_check().canvas2d_store, recurse)
+        self._entries(entries, self._data_check().canvas3d_store, recurse)
+        self._entries(entries, self._data_check().log_store, recurse)
+        return map(lambda n: Field(self._data, self._member, n), entries)
+
+    def has_children(self) -> bool:
+        """「(thisの名前).(追加の名前)」で公開されているデータが1つ以上あればtrue (ver3.1〜)"""
+        return (
+            self._has_entries(self._data_check().value_store)
+            or self._has_entries(self._data_check().text_store)
+            or self._has_entries(self._data_check().image_store)
+            or self._has_entries(self._data_check().func_store)
+            or self._has_entries(self._data_check().view_store)
+            or self._has_entries(self._data_check().canvas2d_store)
+            or self._has_entries(self._data_check().canvas3d_store)
+            or self._has_entries(self._data_check().log_store)
+        )
+
+    def value_entries(self) -> "Iterable[webcface.value.Value]":
+        """「(thisの名前).(追加の名前)」で公開されているvalueをすべて取得する (ver3.1〜)"""
+        entries: List[str] = []
+        self._entries(entries, self._data_check().value_store, True)
+        return map(lambda n: webcface.value.Value(self, n), entries)
+
+    def text_entries(self) -> "Iterable[webcface.text.Text]":
+        """「(thisの名前).(追加の名前)」で公開されているtextをすべて取得する (ver3.1〜)"""
+        entries: List[str] = []
+        self._entries(entries, self._data_check().text_store, True)
+        return map(lambda n: webcface.text.Text(self, n), entries)
+
+    def image_entries(self) -> "Iterable[webcface.image.Image]":
+        """「(thisの名前).(追加の名前)」で公開されているimageをすべて取得する (ver3.1〜)"""
+        entries: List[str] = []
+        self._entries(entries, self._data_check().image_store, True)
+        return map(lambda n: webcface.image.Image(self, n), entries)
+
+    def view_entries(self) -> "Iterable[webcface.view.View]":
+        """「(thisの名前).(追加の名前)」で公開されているviewをすべて取得する (ver3.1〜)"""
+        entries: List[str] = []
+        self._entries(entries, self._data_check().view_store, True)
+        return map(lambda n: webcface.view.View(self, n), entries)
+
+    def func_entries(self) -> "Iterable[webcface.func.Func]":
+        """「(thisの名前).(追加の名前)」で公開されているfuncをすべて取得する (ver3.1〜)"""
+        entries: List[str] = []
+        self._entries(entries, self._data_check().func_store, True)
+        return map(lambda n: webcface.func.Func(self, n), entries)
+
+    def canvas2d_entries(self) -> "Iterable[webcface.canvas2d.Canvas2D]":
+        """「(thisの名前).(追加の名前)」で公開されているcanvas2dをすべて取得する (ver3.1〜)"""
+        entries: List[str] = []
+        self._entries(entries, self._data_check().canvas2d_store, True)
+        return map(lambda n: webcface.canvas2d.Canvas2D(self, n), entries)
+
+    def canvas3d_entries(self) -> "Iterable[webcface.canvas3d.Canvas3D]":
+        """「(thisの名前).(追加の名前)」で公開されているcanvas3dをすべて取得する (ver3.1〜)"""
+        entries: List[str] = []
+        self._entries(entries, self._data_check().canvas3d_store, True)
+        return map(lambda n: webcface.canvas3d.Canvas3D(self, n), entries)
+
+    def log_entries(self) -> "Iterable[webcface.log.Log]":
+        """「(thisの名前).(追加の名前)」で公開されているlogをすべて取得する (ver3.1〜)"""
+        entries: List[str] = []
+        self._entries(entries, self._data_check().log_store, True)
+        return map(lambda n: webcface.log.Log(self, n), entries)

--- a/webcface/field.py
+++ b/webcface/field.py
@@ -1,5 +1,15 @@
 from typing import Callable, Optional, Iterable, SupportsFloat, List
 import webcface.client_data
+import webcface.value
+import webcface.text
+import webcface.view
+import webcface.func
+import webcface.func_listener
+import webcface.log
+import webcface.image
+import webcface.message
+import webcface.canvas2d
+import webcface.canvas3d
 
 
 class FieldBase:

--- a/webcface/func_listener.py
+++ b/webcface/func_listener.py
@@ -3,7 +3,9 @@ import webcface.field
 import webcface.func_info
 
 
-class FuncListener(webcface.field.Field):
+class FuncListener:
+    _base: "webcface.field.Field"
+
     def __init__(
         self,
         base: "Optional[webcface.field.Field]",
@@ -17,29 +19,29 @@ class FuncListener(webcface.field.Field):
         詳細は `Funcのドキュメント <https://na-trium-144.github.io/webcface/md_30__func.html>`_ を参照
         """
         if base is None:
-            super().__init__(None, "", "")
+            self._base = webcface.field.Field(None, "", "")
         else:
-            super().__init__(
+            self._base = webcface.field.Field(
                 base._data, base._member, field if field != "" else base._field
             )
 
     @property
     def member(self) -> "webcface.member.Member":
         """Memberを返す"""
-        return webcface.member.Member(self)
+        return webcface.member.Member(self._base)
 
     @property
     def name(self) -> str:
         """field名を返す"""
-        return self._field
+        return self._base._field
 
     def _set_info(self, info: "webcface.func_info.FuncInfo") -> None:
-        self._set_check().func_store.set_send(self._field, info)
+        self._base._set_check().func_store.set_send(self._base._field, info)
 
     def _handlers(self):
-        if self._field not in self._set_check().func_listener_handlers:
-            self._set_check().func_listener_handlers[self._field] = []
-        return self._set_check().func_listener_handlers[self._field]
+        if self._base._field not in self._base._set_check().func_listener_handlers:
+            self._base._set_check().func_listener_handlers[self._base._field] = []
+        return self._base._set_check().func_listener_handlers[self._base._field]
 
     def listen(
         self,

--- a/webcface/image.py
+++ b/webcface/image.py
@@ -5,26 +5,28 @@ import webcface.message
 import webcface.image_frame
 
 
-class Image(webcface.field.Field):
+class Image:
+    _base: "webcface.field.Field"
+
     def __init__(self, base: "webcface.field.Field", field: str = "") -> None:
         """Imageを指すクラス
 
         このコンストラクタを直接使わず、
         Member.image(), Member.images(), Member.onImageEntry などを使うこと
         """
-        super().__init__(
+        self._base = webcface.field.Field(
             base._data, base._member, field if field != "" else base._field
         )
 
     @property
     def member(self) -> "webcface.member.Member":
         """Memberを返す"""
-        return webcface.member.Member(self)
+        return webcface.member.Member(self._base)
 
     @property
     def name(self) -> str:
         """field名を返す"""
-        return self._field
+        return self._base._field
 
     def on_change(self, func: Callable) -> Callable:
         """値が変化したときのイベント
@@ -34,19 +36,21 @@ class Image(webcface.field.Field):
         まだ値をリクエストされてなければ自動でリクエストされる
         """
         self.request()
-        data = self._data_check()
-        if self._member not in data.on_image_change:
-            data.on_image_change[self._member] = {}
-        data.on_image_change[self._member][self._field] = func
+        data = self._base._data_check()
+        if self._base._member not in data.on_image_change:
+            data.on_image_change[self._base._member] = {}
+        data.on_image_change[self._base._member][self._base._field] = func
         return func
 
     def child(self, field: str) -> "Image":
         """「(thisの名前).(追加の名前)」を新しい名前とするImage"""
-        return Image(webcface.field.Field.child(self, field))
+        return Image(self._base.child(field))
 
     def _try_request(self) -> None:
         # req_dataがNoneの場合以前のreq_dataは上書きされない
-        req = self._data_check().image_store.add_req(self._member, self._field)
+        req = self._base._data_check().image_store.add_req(
+            self._base._member, self._base._field
+        )
         if req > 0:
             self.request()
 
@@ -76,13 +80,15 @@ class Image(webcface.field.Field):
         img_req = webcface.image_frame.ImageReq(
             width, height, color_mode, compress_mode, quality, frame_rate
         )
-        req = self._data_check().image_store.add_req(self._member, self._field, img_req)
+        req = self._base._data_check().image_store.add_req(
+            self._base._member, self._base._field, img_req
+        )
         if req > 0:
-            self._data_check().queue_msg_req(
+            self._base._data_check().queue_msg_req(
                 [
                     webcface.message.ImageReq.new(
-                        self._member,
-                        self._field,
+                        self._base._member,
+                        self._base._field,
                         req,
                         img_req,
                     )
@@ -92,7 +98,9 @@ class Image(webcface.field.Field):
     def try_get(self) -> "Optional[webcface.image_frame.ImageFrame]":
         """画像を返す、まだリクエストされてなければ自動でリクエストされる"""
         self.request()
-        return self._data_check().image_store.get_recv(self._member, self._field)
+        return self._base._data_check().image_store.get_recv(
+            self._base._member, self._base._field
+        )
 
     def get(self) -> "webcface.image_frame.ImageFrame":
         """画像を返す、まだリクエストされてなければ自動でリクエストされる"""
@@ -105,13 +113,17 @@ class Image(webcface.field.Field):
         try_get() などとは違って、実際のデータを受信しない。
         リクエストもしない。
         """
-        return self._field in self._data_check().image_store.get_entry(self._member)
+        return self._base._field in self._base._data_check().image_store.get_entry(
+            self._base._member
+        )
 
     def set(self, data: "webcface.image_frame.ImageFrame") -> "Image":
         """画像をセットする"""
-        self._set_check().image_store.set_send(self._field, data)
+        self._base._set_check().image_store.set_send(self._base._field, data)
         on_change = (
-            self._data_check().on_image_change.get(self._member, {}).get(self._field)
+            self._base._data_check()
+            .on_image_change.get(self._base._member, {})
+            .get(self._base._field)
         )
         if on_change is not None:
             on_change(self)

--- a/webcface/image.py
+++ b/webcface/image.py
@@ -41,11 +41,8 @@ class Image(webcface.field.Field):
         return func
 
     def child(self, field: str) -> "Image":
-        """子フィールドを返す
-
-        :return: 「(thisのフィールド名).(子フィールド名)」をフィールド名とするImage
-        """
-        return Image(self, self._field + "." + field)
+        """「(thisの名前).(追加の名前)」を新しい名前とするImage"""
+        return Image(webcface.field.Field.child(self, field))
 
     def _try_request(self) -> None:
         # req_dataがNoneの場合以前のreq_dataは上書きされない

--- a/webcface/log.py
+++ b/webcface/log.py
@@ -32,6 +32,10 @@ class Log(webcface.field.Field):
         """field名を返す(ver2.1〜)"""
         return self._field
 
+    def child(self, field: str) -> "Log":
+        """「(thisの名前).(追加の名前)」を新しい名前とするLog (ver3.1〜)"""
+        return Log(webcface.field.Field.child(self, field))
+
     def on_change(self, func: Callable) -> Callable:
         """logが追加されたときのイベント
         (ver2.0〜)

--- a/webcface/log.py
+++ b/webcface/log.py
@@ -7,8 +7,9 @@ import webcface.member
 import webcface.log_handler
 
 
-class Log(webcface.field.Field):
+class Log:
     keep_lines: int = 1000
+    _base: "webcface.field.Field"
 
     def __init__(self, base: "webcface.field.Field", field: str = "") -> None:
         """Logを指すクラス
@@ -18,23 +19,23 @@ class Log(webcface.field.Field):
 
         詳細は `Logのドキュメント <https://na-trium-144.github.io/webcface/md_40__log.html>`_ を参照
         """
-        super().__init__(
+        self._base = webcface.field.Field(
             base._data, base._member, field if field != "" else base._field
         )
 
     @property
     def member(self) -> "webcface.member.Member":
         """Memberを返す"""
-        return webcface.member.Member(self)
+        return webcface.member.Member(self._base)
 
     @property
     def name(self) -> str:
         """field名を返す(ver2.1〜)"""
-        return self._field
+        return self._base._field
 
     def child(self, field: str) -> "Log":
         """「(thisの名前).(追加の名前)」を新しい名前とするLog (ver3.1〜)"""
-        return Log(webcface.field.Field.child(self, field))
+        return Log(self._base.child(field))
 
     def on_change(self, func: Callable) -> Callable:
         """logが追加されたときのイベント
@@ -45,21 +46,29 @@ class Log(webcface.field.Field):
         まだ値をリクエストされてなければ自動でリクエストされる
         """
         self.request()
-        self._data_check().on_log_change[self._member] = func
+        self._base._data_check().on_log_change[self._base._member] = func
         return func
 
     def request(self) -> None:
         """値の受信をリクエストする"""
-        req = self._data_check().log_store.add_req(self._member, self._field)
+        req = self._base._data_check().log_store.add_req(
+            self._base._member, self._base._field
+        )
         if req:
-            self._data_check().queue_msg_req(
-                [webcface.message.LogReq.new(self._member, self._field, req)]
+            self._base._data_check().queue_msg_req(
+                [
+                    webcface.message.LogReq.new(
+                        self._base._member, self._base._field, req
+                    )
+                ]
             )
 
     def try_get(self) -> "Optional[List[webcface.log_handler.LogLine]]":
         """ログをlistまたはNoneで返す、まだリクエストされてなければ自動でリクエストされる"""
         self.request()
-        log_data = self._data_check().log_store.get_recv(self._member, self._field)
+        log_data = self._base._data_check().log_store.get_recv(
+            self._base._member, self._base._field
+        )
         if log_data is not None:
             return log_data.data[:]
         else:
@@ -74,7 +83,9 @@ class Log(webcface.field.Field):
         """受信したログを空にする
 
         リクエスト状態はクリアしない"""
-        log_data = self._data_check().log_store.get_recv(self._member, self._field)
+        log_data = self._base._data_check().log_store.get_recv(
+            self._base._member, self._base._field
+        )
         if log_data is not None:
             log_data.data = []
         return self
@@ -86,7 +97,9 @@ class Log(webcface.field.Field):
         try_get() などとは違って、実際のデータを受信しない。
         リクエストもしない。
         """
-        return self._field in self._data_check().log_store.get_entry(self._member)
+        return self._base._field in self._base._data_check().log_store.get_entry(
+            self._base._member
+        )
 
     def append(
         self,
@@ -99,13 +112,13 @@ class Log(webcface.field.Field):
 
         コンソールなどには出力されない
         """
-        data = self._set_check()
+        data = self._base._set_check()
         with data.log_store.lock:
-            log_data = data.log_store.get_recv(self._member, self._field)
+            log_data = data.log_store.get_recv(self._base._member, self._base._field)
             if log_data is None:
                 log_data = webcface.log_handler.LogData()
             log_data.data.append(webcface.log_handler.LogLine(level, time, message))
-            data.log_store.set_send(self._field, log_data)
+            data.log_store.set_send(self._base._field, log_data)
 
     @property
     def handler(self) -> logging.Handler:
@@ -114,11 +127,13 @@ class Log(webcface.field.Field):
 
         :return: logger.addHandler にセットして使う
         """
-        return webcface.log_handler.Handler(self._data_check(), self._field)
+        return webcface.log_handler.Handler(self._base._data_check(), self._base._field)
 
     @property
     def io(self) -> io.TextIOBase:
         """webcfaceとstderrに出力するio
         (ver2.1〜)
         """
-        return webcface.log_handler.LogWriteIO(self._data_check(), self._field)
+        return webcface.log_handler.LogWriteIO(
+            self._base._data_check(), self._base._field
+        )

--- a/webcface/member.py
+++ b/webcface/member.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Iterable, SupportsFloat
+from typing import Callable, Optional, Iterable
 import datetime
 import webcface.field
 import webcface.value
@@ -29,82 +29,12 @@ class Member(webcface.field.Field):
         """Member名"""
         return self._member
 
-    def value(self, field: str) -> "webcface.value.Value":
-        """Valueオブジェクトを生成"""
-        return webcface.value.Value(self, field)
-
-    def text(self, field: str) -> "webcface.text.Text":
-        """Textオブジェクトを生成"""
-        return webcface.text.Text(self, field)
-
-    def variant(self, field: str) -> "webcface.text.Variant":
-        """Variantオブジェクトを生成 (ver2.0〜)"""
-        return webcface.text.Variant(self, field)
-
-    def image(self, field: str) -> "webcface.image.Image":
-        """Imageオブジェクトを生成"""
-        return webcface.image.Image(self, field)
-
-    def view(self, field: str) -> "webcface.view.View":
-        """Viewオブジェクトを生成"""
-        return webcface.view.View(self, field)
-
-    def canvas2d(
-        self,
-        field: str,
-        width: Optional[SupportsFloat] = None,
-        height: Optional[SupportsFloat] = None,
-    ) -> "webcface.canvas2d.Canvas2D":
-        """Canvas2Dオブジェクトを生成
-
-        :arg width, height: Canvas2Dのサイズを指定して初期化する
-        """
-        return webcface.canvas2d.Canvas2D(self, field, width, height)
-
-    def canvas3d(self, field: str) -> "webcface.canvas3d.Canvas3D":
-        """Canvas3Dオブジェクトを生成"""
-        return webcface.canvas3d.Canvas3D(self, field)
-
-    def log(self, field: str = "default") -> "webcface.log.Log":
-        """Logオブジェクトを生成
-
-        :arg field: (ver2.1〜) Logの名前を指定可能(省略すると"default")
-        """
-        return webcface.log.Log(self, field)
-
-    def func(self, arg: str = "", **kwargs) -> "webcface.func.Func":
-        """Funcオブジェクトを生成
-
-        #. member.func(arg: str)
-            * 指定した名前のFuncオブジェクトを生成・参照する。
-        #. @member.func(arg: str, [**kwargs])
-            * デコレータとして使い、デコレートした関数を指定した名前でセットする。
-            * デコレート後、関数は元のまま返す。
-        #. @member.func([**kwargs])
-            * 3と同じだが、名前はデコレートした関数から自動で取得される。
-        #. member.func(arg: Callable, [**kwargs])
-            * これはver2.0で削除。
-
-        2, 3 の場合のkwargsは Func.set() を参照。
-        """
-        return webcface.func.Func(self, arg, **kwargs)
-
-    def func_listener(self, field: str) -> "webcface.func_listener.FuncListener":
-        """FuncListenerオブジェクトを生成
-        (ver2.2〜)
-        """
-        return webcface.func_listener.FuncListener(self, field)
-
     def values(self) -> "Iterable[webcface.value.Value]":
         """このメンバーのValueをすべて取得する。
 
         .. deprecated:: 1.1
         """
         return self.value_entries()
-
-    def value_entries(self) -> "Iterable[webcface.value.Value]":
-        """このメンバーのValueをすべて取得する。"""
-        return map(self.value, self._data_check().value_store.get_entry(self._member))
 
     def texts(self) -> "Iterable[webcface.text.Text]":
         """このメンバーのTextをすべて取得する。
@@ -113,14 +43,6 @@ class Member(webcface.field.Field):
         """
         return self.text_entries()
 
-    def text_entries(self) -> "Iterable[webcface.text.Text]":
-        """このメンバーのTextをすべて取得する。"""
-        return map(self.text, self._data_check().text_store.get_entry(self._member))
-
-    def image_entries(self) -> "Iterable[webcface.image.Image]":
-        """このメンバーのImageをすべて取得する。"""
-        return map(self.image, self._data_check().image_store.get_entry(self._member))
-
     def views(self) -> "Iterable[webcface.view.View]":
         """このメンバーのViewをすべて取得する。
 
@@ -128,36 +50,12 @@ class Member(webcface.field.Field):
         """
         return self.view_entries()
 
-    def view_entries(self) -> "Iterable[webcface.view.View]":
-        """このメンバーのViewをすべて取得する。"""
-        return map(self.view, self._data_check().view_store.get_entry(self._member))
-
     def funcs(self) -> "Iterable[webcface.func.Func]":
         """このメンバーのFuncをすべて取得する。
 
         .. deprecated:: 1.1
         """
         return self.func_entries()
-
-    def func_entries(self) -> "Iterable[webcface.func.Func]":
-        """このメンバーのFuncをすべて取得する。"""
-        return map(self.func, self._data_check().func_store.get_entry(self._member))
-
-    def canvas2d_entries(self) -> "Iterable[webcface.canvas2d.Canvas2D]":
-        """このメンバーのCanvas2Dをすべて取得する。"""
-        return map(
-            self.canvas2d, self._data_check().canvas2d_store.get_entry(self._member)
-        )
-
-    def canvas3d_entries(self) -> "Iterable[webcface.canvas3d.Canvas3D]":
-        """このメンバーのCanvas3Dをすべて取得する。"""
-        return map(
-            self.canvas3d, self._data_check().canvas3d_store.get_entry(self._member)
-        )
-
-    def log_entries(self) -> "Iterable[webcface.log.Log]":
-        """このメンバーのLogをすべて取得する。(ver2.1〜)"""
-        return map(self.log, self._data_check().log_store.get_entry(self._member))
 
     def on_value_entry(self, func: Callable) -> Callable:
         """Valueが追加されたときのイベント

--- a/webcface/text.py
+++ b/webcface/text.py
@@ -128,7 +128,7 @@ class Text(Variant):
 
         まだ値をリクエストされてなければ自動でリクエストされる
         """
-        super().on_change(lambda var: func(Text(var)))
+        super().on_change(lambda var: func(Text(var._base)))
         return func
 
     def child(self, field: str) -> "Text":

--- a/webcface/text.py
+++ b/webcface/text.py
@@ -39,11 +39,8 @@ class Variant(webcface.field.Field):
         return func
 
     def child(self, field: str) -> "Variant":
-        """子フィールドを返す
-
-        :return: 「(thisのフィールド名).(子フィールド名)」をフィールド名とするText
-        """
-        return Variant(self, self._field + "." + field)
+        """「(thisの名前).(追加の名前)」を新しい名前とするVariant"""
+        return Variant(webcface.field.Field.child(self, field))
 
     def request(self) -> None:
         """値の受信をリクエストする"""
@@ -121,11 +118,8 @@ class Text(Variant):
         return func
 
     def child(self, field: str) -> "Text":
-        """子フィールドを返す
-
-        :return: 「(thisのフィールド名).(子フィールド名)」をフィールド名とするText
-        """
-        return Text(super().child(field))
+        """「(thisの名前).(追加の名前)」を新しい名前とするText"""
+        return Text(webcface.field.Field.child(self, field))
 
     def try_get(self) -> Optional[str]:
         """文字列をstrまたはNoneで返す、まだリクエストされてなければ自動でリクエストされる"""

--- a/webcface/text.py
+++ b/webcface/text.py
@@ -4,24 +4,26 @@ import webcface.member
 from webcface.typing import convertible_to_float
 
 
-class Variant(webcface.field.Field):
+class Variant:
+    _base: "webcface.field.Field"
+
     def __init__(self, base: "webcface.field.Field", field: str = "") -> None:
         """文字列、数値などの型を送受信するVariantを指すクラス
         (ver2.0〜)
         """
-        super().__init__(
+        self._base = webcface.field.Field(
             base._data, base._member, field if field != "" else base._field
         )
 
     @property
     def member(self) -> "webcface.member.Member":
         """Memberを返す"""
-        return webcface.member.Member(self)
+        return webcface.member.Member(self._base)
 
     @property
     def name(self) -> str:
         """field名を返す"""
-        return self._field
+        return self._base._field
 
     def on_change(self, func: Callable) -> Callable:
         """値が変化したときのイベント
@@ -32,28 +34,36 @@ class Variant(webcface.field.Field):
         まだ値をリクエストされてなければ自動でリクエストされる
         """
         self.request()
-        data = self._data_check()
-        if self._member not in data.on_text_change:
-            data.on_text_change[self._member] = {}
-        data.on_text_change[self._member][self._field] = func
+        data = self._base._data_check()
+        if self._base._member not in data.on_text_change:
+            data.on_text_change[self._base._member] = {}
+        data.on_text_change[self._base._member][self._base._field] = func
         return func
 
     def child(self, field: str) -> "Variant":
         """「(thisの名前).(追加の名前)」を新しい名前とするVariant"""
-        return Variant(webcface.field.Field.child(self, field))
+        return Variant(self._base.child(field))
 
     def request(self) -> None:
         """値の受信をリクエストする"""
-        req = self._data_check().text_store.add_req(self._member, self._field)
+        req = self._base._data_check().text_store.add_req(
+            self._base._member, self._base._field
+        )
         if req > 0:
-            self._data_check().queue_msg_req(
-                [webcface.message.TextReq.new(self._member, self._field, req)]
+            self._base._data_check().queue_msg_req(
+                [
+                    webcface.message.TextReq.new(
+                        self._base._member, self._base._field, req
+                    )
+                ]
             )
 
     def try_get(self) -> Optional[Union[float, bool, str]]:
         """データまたはNoneを返す、まだリクエストされてなければ自動でリクエストされる"""
         self.request()
-        return self._data_check().text_store.get_recv(self._member, self._field)
+        return self._base._data_check().text_store.get_recv(
+            self._base._member, self._base._field
+        )
 
     def get(self) -> Union[float, bool, str]:
         """データを返す、まだリクエストされてなければ自動でリクエストされる"""
@@ -67,7 +77,9 @@ class Variant(webcface.field.Field):
         try_get() などとは違って、実際のデータを受信しない。
         リクエストもしない。
         """
-        return self._field in self._data_check().text_store.get_entry(self._member)
+        return self._base._field in self._base._data_check().text_store.get_entry(
+            self._base._member
+        )
 
     def __str__(self) -> str:
         """printしたときなど
@@ -86,9 +98,11 @@ class Variant(webcface.field.Field):
             data2 = float(data)
         else:
             data2 = str(data)
-        self._set_check().text_store.set_send(self._field, data2)
+        self._base._set_check().text_store.set_send(self._base._field, data2)
         on_change = (
-            self._data_check().on_text_change.get(self._member, {}).get(self._field)
+            self._base._data_check()
+            .on_text_change.get(self._base._member, {})
+            .get(self._base._field)
         )
         if on_change is not None:
             on_change(self)
@@ -119,7 +133,7 @@ class Text(Variant):
 
     def child(self, field: str) -> "Text":
         """「(thisの名前).(追加の名前)」を新しい名前とするText"""
-        return Text(webcface.field.Field.child(self, field))
+        return Text(self._base.child(field))
 
     def try_get(self) -> Optional[str]:
         """文字列をstrまたはNoneで返す、まだリクエストされてなければ自動でリクエストされる"""

--- a/webcface/value.py
+++ b/webcface/value.py
@@ -44,11 +44,8 @@ class Value(webcface.field.Field):
         return func
 
     def child(self, field: str) -> "Value":
-        """子フィールドを返す
-
-        :return: 「(thisのフィールド名).(子フィールド名)」をフィールド名とするValue
-        """
-        return Value(self, self._field + "." + field)
+        """「(thisの名前).(追加の名前)」を新しい名前とするValue"""
+        return Value(webcface.field.Field.child(self, field))
 
     def request(self) -> None:
         """値の受信をリクエストする"""

--- a/webcface/value.py
+++ b/webcface/value.py
@@ -5,7 +5,9 @@ import webcface.message
 from webcface.typing import convertible_to_float
 
 
-class Value(webcface.field.Field):
+class Value:
+    _base: "webcface.field.Field"
+
     def __init__(self, base: "webcface.field.Field", field: str = "") -> None:
         """Valueを指すクラス
 
@@ -14,19 +16,19 @@ class Value(webcface.field.Field):
 
         詳細は `Valueのドキュメント <https://na-trium-144.github.io/webcface/md_10__value.html>`_ を参照
         """
-        super().__init__(
+        self._base = webcface.field.Field(
             base._data, base._member, field if field != "" else base._field
         )
 
     @property
     def member(self) -> "webcface.member.Member":
         """Memberを返す"""
-        return webcface.member.Member(self)
+        return webcface.member.Member(self._base)
 
     @property
     def name(self) -> str:
         """field名を返す"""
-        return self._field
+        return self._base._field
 
     def on_change(self, func: Callable) -> Callable:
         """値が変化したときのイベント
@@ -37,28 +39,36 @@ class Value(webcface.field.Field):
         まだ値をリクエストされてなければ自動でリクエストされる
         """
         self.request()
-        data = self._data_check()
-        if self._member not in data.on_value_change:
-            data.on_value_change[self._member] = {}
-        data.on_value_change[self._member][self._field] = func
+        data = self._base._data_check()
+        if self._base._member not in data.on_value_change:
+            data.on_value_change[self._base._member] = {}
+        data.on_value_change[self._base._member][self._base._field] = func
         return func
 
     def child(self, field: str) -> "Value":
         """「(thisの名前).(追加の名前)」を新しい名前とするValue"""
-        return Value(webcface.field.Field.child(self, field))
+        return Value(self._base.child(field))
 
     def request(self) -> None:
         """値の受信をリクエストする"""
-        req = self._data_check().value_store.add_req(self._member, self._field)
+        req = self._base._data_check().value_store.add_req(
+            self._base._member, self._base._field
+        )
         if req > 0:
-            self._data_check().queue_msg_req(
-                [webcface.message.ValueReq.new(self._member, self._field, req)]
+            self._base._data_check().queue_msg_req(
+                [
+                    webcface.message.ValueReq.new(
+                        self._base._member, self._base._field, req
+                    )
+                ]
             )
 
     def try_get_vec(self) -> Optional[List[float]]:
         """値をlistまたはNoneで返す、まだリクエストされてなければ自動でリクエストされる"""
         self.request()
-        return self._data_check().value_store.get_recv(self._member, self._field)
+        return self._base._data_check().value_store.get_recv(
+            self._base._member, self._base._field
+        )
 
     def try_get(self) -> Optional[float]:
         """値をfloatまたはNoneで返す、まだリクエストされてなければ自動でリクエストされる"""
@@ -82,7 +92,9 @@ class Value(webcface.field.Field):
         try_get() などとは違って、実際のデータを受信しない。
         リクエストもしない。
         """
-        return self._field in self._data_check().value_store.get_entry(self._member)
+        return self._base._field in self._base._data_check().value_store.get_entry(
+            self._base._member
+        )
 
     def __str__(self) -> str:
         """printしたときなど
@@ -93,17 +105,21 @@ class Value(webcface.field.Field):
 
     def set(self, data: Union[List[SupportsFloat], SupportsFloat]) -> "Value":
         """値をセットする"""
-        self._set_check()
+        self._base._set_check()
         if convertible_to_float(data):
-            self._set_check().value_store.set_send(self._field, [float(data)])
+            self._base._set_check().value_store.set_send(
+                self._base._field, [float(data)]
+            )
         elif isinstance(data, list):
-            self._set_check().value_store.set_send(
-                self._field, [float(v) for v in data]
+            self._base._set_check().value_store.set_send(
+                self._base._field, [float(v) for v in data]
             )
         else:
             raise TypeError("unsupported data type for value.set(): " + str(data))
         on_change = (
-            self._data_check().on_value_change.get(self._member, {}).get(self._field)
+            self._base._data_check()
+            .on_value_change.get(self._base._member, {})
+            .get(self._base._field)
         )
         if on_change is not None:
             on_change(self)

--- a/webcface/view.py
+++ b/webcface/view.py
@@ -207,11 +207,8 @@ class View(webcface.field.Field):
         return func
 
     def child(self, field: str) -> "View":
-        """子フィールドを返す
-
-        :return: 「(thisのフィールド名).(子フィールド名)」をフィールド名とするView
-        """
-        return View(self, self._field + "." + field)
+        """「(thisの名前).(追加の名前)」を新しい名前とするView"""
+        return View(webcface.field.Field.child(self, field))
 
     def request(self) -> None:
         """値の受信をリクエストする"""

--- a/webcface/view.py
+++ b/webcface/view.py
@@ -163,7 +163,8 @@ class ViewComponent(webcface.view_base.ViewComponentBase):
         return self._option
 
 
-class View(webcface.field.Field):
+class View:
+    _base: "webcface.field.Field"
     _vdata: "Optional[ViewData]"
     _modified: bool
 
@@ -175,7 +176,7 @@ class View(webcface.field.Field):
 
         詳細は `Viewのドキュメント <https://na-trium-144.github.io/webcface/md_13__view.html>`_ を参照
         """
-        super().__init__(
+        self._base = webcface.field.Field(
             base._data, base._member, field if field != "" else base._field
         )
         self._vdata = None
@@ -184,12 +185,12 @@ class View(webcface.field.Field):
     @property
     def member(self) -> "webcface.member.Member":
         """Memberを返す"""
-        return webcface.member.Member(self)
+        return webcface.member.Member(self._base)
 
     @property
     def name(self) -> str:
         """field名を返す"""
-        return self._field
+        return self._base._field
 
     def on_change(self, func: Callable) -> Callable:
         """値が変化したときのイベント
@@ -200,31 +201,42 @@ class View(webcface.field.Field):
         まだ値をリクエストされてなければ自動でリクエストされる
         """
         self.request()
-        data = self._data_check()
-        if self._member not in data.on_view_change:
-            data.on_view_change[self._member] = {}
-        data.on_view_change[self._member][self._field] = func
+        data = self._base._data_check()
+        if self._base._member not in data.on_view_change:
+            data.on_view_change[self._base._member] = {}
+        data.on_view_change[self._base._member][self._base._field] = func
         return func
 
     def child(self, field: str) -> "View":
         """「(thisの名前).(追加の名前)」を新しい名前とするView"""
-        return View(webcface.field.Field.child(self, field))
+        return View(self._base.child(field))
 
     def request(self) -> None:
         """値の受信をリクエストする"""
-        req = self._data_check().view_store.add_req(self._member, self._field)
+        req = self._base._data_check().view_store.add_req(
+            self._base._member, self._base._field
+        )
         if req > 0:
-            self._data_check().queue_msg_req(
-                [webcface.message.ViewReq.new(self._member, self._field, req)]
+            self._base._data_check().queue_msg_req(
+                [
+                    webcface.message.ViewReq.new(
+                        self._base._member, self._base._field, req
+                    )
+                ]
             )
 
     def try_get(self) -> Optional[List[ViewComponent]]:
         """ViewをlistまたはNoneで返す、まだリクエストされてなければ自動でリクエストされる"""
         self.request()
-        v = self._data_check().view_store.get_recv(self._member, self._field)
+        v = self._base._data_check().view_store.get_recv(
+            self._base._member, self._base._field
+        )
         v2: Optional[List[ViewComponent]] = None
         if v is not None:
-            v2 = [ViewComponent(v.components[v_id], self._data, v_id) for v_id in v.ids]
+            v2 = [
+                ViewComponent(v.components[v_id], self._base._data, v_id)
+                for v_id in v.ids
+            ]
         return v2
 
     def get(self) -> List[ViewComponent]:
@@ -239,7 +251,9 @@ class View(webcface.field.Field):
         try_get() などとは違って、実際のデータを受信しない。
         リクエストもしない。
         """
-        return self._field in self._data_check().view_store.get_entry(self._member)
+        return self._base._field in self._base._data_check().view_store.get_entry(
+            self._base._member
+        )
 
     def set(
         self,
@@ -277,20 +291,22 @@ class View(webcface.field.Field):
 
     def sync(self) -> "View":
         """Viewの内容をclientに反映し送信可能にする"""
-        self._set_check()
+        self._base._set_check()
         if self._modified and self._vdata is not None:
-            data = self._set_check()
+            data = self._base._set_check()
             self._vdata.components = {}
             self._vdata.ids = []
             data_idx: Dict[int, int] = {}
             for c in self._vdata.tmp_components:
                 idx = data_idx.get(c._view_type, 0)
                 data_idx[c._view_type] = idx + 1
-                c.lock_tmp(data, "v", self._field, f"..{c._view_type}.{idx}")
+                c.lock_tmp(data, "v", self._base._field, f"..{c._view_type}.{idx}")
                 self._vdata.components[c.id] = c.to_view()
                 self._vdata.ids.append(c.id)
-            data.view_store.set_send(self._field, self._vdata)
-            on_change = data.on_view_change.get(self._member, {}).get(self._field)
+            data.view_store.set_send(self._base._field, self._vdata)
+            on_change = data.on_view_change.get(self._base._member, {}).get(
+                self._base._field
+            )
             if on_change is not None:
                 on_change(self)
             self._modified = False


### PR DESCRIPTION
https://github.com/na-trium-144/webcface/pull/464 に対応

* Field.member(), name(), child(), children(), has\_children(), 各種データ型の関数(value(), text(), ...と、 value\_entries(), text\_entries(), ...) 追加
* Log.child() がなかったので追加
* Value, Textなど各種データ型がFieldを継承するのをやめる
